### PR TITLE
Add modal behavior and parent focus to ModalWindow

### DIFF
--- a/WinUI3Package/ModalWindow.cpp
+++ b/WinUI3Package/ModalWindow.cpp
@@ -8,11 +8,21 @@
 
 namespace winrt::WinUI3Package::implementation
 {
-	ModalWindow::ModalWindow(winrt::Microsoft::UI::Xaml::Window const& parent)
+	ModalWindow::ModalWindow(winrt::Microsoft::UI::Xaml::Window const& parent) : m_owner(parent)
 	{
+		m_closedRevoker = Closed(winrt::auto_revoke, { this, &ModalWindow::OnClosed });
+
 		SetWindowLongPtr(GetHwnd(*this), GWLP_HWNDPARENT, reinterpret_cast<LONG_PTR>(GetHwnd(parent)));
 		auto appWindow = AppWindow();
 		appWindow.Presenter().as<winrt::Microsoft::UI::Windowing::OverlappedPresenter>().IsModal(true);
 		appWindow.Show();
+	}
+
+	void ModalWindow::OnClosed(winrt::Windows::Foundation::IInspectable const&, winrt::Microsoft::UI::Xaml::WindowEventArgs const&)
+	{
+		if (m_owner)
+		{
+			m_owner.Activate();
+		}
 	}
 }

--- a/WinUI3Package/ModalWindow.h
+++ b/WinUI3Package/ModalWindow.h
@@ -4,16 +4,22 @@
 
 namespace winrt::WinUI3Package::implementation
 {
-    struct ModalWindow : ModalWindowT<ModalWindow>
-    {
+	struct ModalWindow : ModalWindowT<ModalWindow>
+	{
 		ModalWindow() = default;
 		ModalWindow(winrt::Microsoft::UI::Xaml::Window const& parent);
-    };
+
+	private:
+		void OnClosed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::WindowEventArgs const& args);
+
+		winrt::Microsoft::UI::Xaml::Window m_owner{ nullptr };
+		winrt::Microsoft::UI::Xaml::Window::Closed_revoker m_closedRevoker{};
+	};
 }
 
 namespace winrt::WinUI3Package::factory_implementation
 {
-    struct ModalWindow : ModalWindowT<ModalWindow, implementation::ModalWindow>
-    {
-    };
+	struct ModalWindow : ModalWindowT<ModalWindow, implementation::ModalWindow>
+	{
+	};
 }


### PR DESCRIPTION
ModalWindow now supports true modal behavior by accepting a parent window, setting the parent HWND, and marking itself as modal using OverlappedPresenter. An OnClosed handler ensures the parent window is re-activated when the modal window closes. References to the parent window and a Closed event revoker are now maintained for proper event management.