### PR TITLE
Add TeachingTipHelper

### DIFF
--- a/WinUI3Example/MainWindow.xaml.cpp
+++ b/WinUI3Example/MainWindow.xaml.cpp
@@ -55,6 +55,7 @@
 #include "RevealFocusPage.xaml.h"
 #include "TenMicaPage.xaml.h"
 #include "SliderHelperPage.xaml.h"
+#include "TeachingTipHelperPage.xaml.h"
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.

--- a/WinUI3Example/MainWindow.xaml.h
+++ b/WinUI3Example/MainWindow.xaml.h
@@ -58,6 +58,7 @@ namespace winrt::WinUI3Example::implementation
 	struct RevealFocusPage;
     struct TenMicaPage;
     struct SliderHelperPage;
+    struct TeachingTipHelperPage;
 
     struct MainWindow : MainWindowT<MainWindow>
     {
@@ -131,7 +132,8 @@ namespace winrt::WinUI3Example::implementation
 			boost::hana::make_pair(L"NavigationViewHelper", boost::hana::type_c<WinUI3Example::implementation::NavigationViewHelperPage>),
             boost::hana::make_pair(L"RevealFocus", boost::hana::type_c<WinUI3Example::implementation::RevealFocusPage>),
             boost::hana::make_pair(L"TenMica", boost::hana::type_c<WinUI3Example::implementation::TenMicaPage>),
-            boost::hana::make_pair(L"SliderHelper", boost::hana::type_c<WinUI3Example::implementation::SliderHelperPage>)
+            boost::hana::make_pair(L"SliderHelper", boost::hana::type_c<WinUI3Example::implementation::SliderHelperPage>),
+            boost::hana::make_pair(L"TeachingTipHelper", boost::hana::type_c<WinUI3Example::implementation::TeachingTipHelperPage>)
         );
 
         static constexpr void iteratePageType(std::wstring_view key, auto&& onFound)

--- a/WinUI3Example/TeachingTipHelperPage.idl
+++ b/WinUI3Example/TeachingTipHelperPage.idl
@@ -1,0 +1,8 @@
+namespace WinUI3Example
+{
+    [default_interface]
+    runtimeclass TeachingTipHelperPage : Microsoft.UI.Xaml.Controls.Page
+    {
+        TeachingTipHelperPage();
+    }
+}

--- a/WinUI3Example/TeachingTipHelperPage.xaml
+++ b/WinUI3Example/TeachingTipHelperPage.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page
+    x:Class="WinUI3Example.TeachingTipHelperPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:essential="using:WinUI3Package"
+    xmlns:local="using:WinUI3Example"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+        <Button
+            x:Name="TestButton1"
+            Click="TestButton1_Click"
+            Content="Show TeachingTip" />
+        <TeachingTip
+            x:Name="TestButton1TeachingTip"
+            Title="This is the title"
+            essential:TeachingTipHelper.AcrylicWorkaround="True"
+            Subtitle="And this is the subtitle"
+            Target="{x:Bind TestButton1}">
+            <TeachingTip.IconSource>
+                <SymbolIconSource Symbol="Refresh" />
+            </TeachingTip.IconSource>
+        </TeachingTip>
+    </Grid>
+</Page>

--- a/WinUI3Example/TeachingTipHelperPage.xaml.cpp
+++ b/WinUI3Example/TeachingTipHelperPage.xaml.cpp
@@ -1,0 +1,19 @@
+#include "pch.h"
+#include "TeachingTipHelperPage.xaml.h"
+#if __has_include("TeachingTipHelperPage.g.cpp")
+#include "TeachingTipHelperPage.g.cpp"
+#endif
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace winrt::WinUI3Example::implementation
+{
+
+	void TeachingTipHelperPage::TestButton1_Click(
+		winrt::Windows::Foundation::IInspectable const&, 
+		winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
+	{
+		TestButton1TeachingTip().IsOpen(true);
+	}
+}

--- a/WinUI3Example/TeachingTipHelperPage.xaml.h
+++ b/WinUI3Example/TeachingTipHelperPage.xaml.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "TeachingTipHelperPage.g.h"
+
+namespace winrt::WinUI3Example::implementation
+{
+    struct TeachingTipHelperPage : TeachingTipHelperPageT<TeachingTipHelperPage>
+    {
+        TeachingTipHelperPage() = default;
+        void TestButton1_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
+    };
+}
+
+namespace winrt::WinUI3Example::factory_implementation
+{
+    struct TeachingTipHelperPage : TeachingTipHelperPageT<TeachingTipHelperPage, implementation::TeachingTipHelperPage>
+    {
+    };
+}

--- a/WinUI3Example/WinUI3Example.vcxproj
+++ b/WinUI3Example/WinUI3Example.vcxproj
@@ -605,6 +605,10 @@
       <DependentUpon>TaskbarPage.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="TeachingTipHelperPage.xaml.h">
+      <DependentUpon>TeachingTipHelperPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="TemplateInformation.h">
       <DependentUpon>TemplateInformation.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -869,6 +873,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="TaskbarPage.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="TeachingTipHelperPage.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Include="TenMicaBackdropWindow.xaml">
@@ -1249,6 +1256,10 @@
     </ClCompile>
     <ClCompile Include="TaskbarPage.xaml.cpp">
       <DependentUpon>TaskbarPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
+    <ClCompile Include="TeachingTipHelperPage.xaml.cpp">
+      <DependentUpon>TeachingTipHelperPage.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
     <ClCompile Include="TenMicaBackdropWindow.xaml.cpp">
@@ -1633,6 +1644,10 @@
     </Midl>
     <Midl Include="TaskbarPage.idl">
       <DependentUpon>TaskbarPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="TeachingTipHelperPage.idl">
+      <DependentUpon>TeachingTipHelperPage.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="TemplateInformation.idl">

--- a/WinUI3Example/WinUI3Example.vcxproj.filters
+++ b/WinUI3Example/WinUI3Example.vcxproj.filters
@@ -248,6 +248,9 @@
     <Page Include="SliderHelperPage.xaml">
       <Filter>Pages</Filter>
     </Page>
+    <Page Include="TeachingTipHelperPage.xaml">
+      <Filter>Pages</Filter>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="App.idl" />

--- a/WinUI3Package/TeachingTipHelper.cpp
+++ b/WinUI3Package/TeachingTipHelper.cpp
@@ -42,7 +42,6 @@ namespace winrt::WinUI3Package::implementation
 
 	void ApplyAcrylicToGrid(winrt::Microsoft::UI::Xaml::Controls::Grid const& grid)
 	{
-		// 1. 保存原始 Background 和 CornerRadius
 		auto originalBackground = grid.Background();
 		auto cornerRadius = grid.CornerRadius();
 

--- a/WinUI3Package/TeachingTipHelper.cpp
+++ b/WinUI3Package/TeachingTipHelper.cpp
@@ -1,0 +1,143 @@
+﻿#include "pch.h"
+#include "TeachingTipHelper.h"
+#if __has_include("TeachingTipHelper.g.cpp")
+#include "TeachingTipHelper.g.cpp"
+#endif
+
+#include "VisualTreeHelper.hpp"
+#include "AcrylicVisual.h"
+#include "AcrylicVisualWithBoundedCornerRadius.h"
+
+namespace winrt::WinUI3Package::implementation
+{
+	winrt::Microsoft::UI::Xaml::DependencyProperty TeachingTipHelper::s_acrylicWorkaroundProperty =
+		winrt::Microsoft::UI::Xaml::DependencyProperty::RegisterAttached(
+			L"AcrylicWorkaround",
+			winrt::xaml_typename<bool>(),
+			winrt::xaml_typename<class_type>(),
+			winrt::Microsoft::UI::Xaml::PropertyMetadata{
+				nullptr,
+				&TeachingTipHelper::acrylicWorkaroundChanged
+			}
+		);
+
+	winrt::Microsoft::UI::Xaml::DependencyProperty TeachingTipHelper::AcrylicWorkaroundProperty()
+	{
+		return s_acrylicWorkaroundProperty;
+	}
+
+	bool TeachingTipHelper::GetAcrylicWorkaround(winrt::Microsoft::UI::Xaml::Controls::TeachingTip const& teachingTip)
+	{
+		return winrt::unbox_value<bool>(teachingTip.GetValue(AcrylicWorkaroundProperty()));
+	}
+
+	void TeachingTipHelper::SetAcrylicWorkaround(
+		winrt::Microsoft::UI::Xaml::Controls::TeachingTip const& teachingTip,
+		bool value
+	)
+	{
+		teachingTip.SetValue(AcrylicWorkaroundProperty(), winrt::box_value(value));
+	}
+
+
+	void ApplyAcrylicToGrid(winrt::Microsoft::UI::Xaml::Controls::Grid const& grid)
+	{
+		// 1. 保存原始 Background 和 CornerRadius
+		auto originalBackground = grid.Background();
+		auto cornerRadius = grid.CornerRadius();
+
+		grid.Background(winrt::Microsoft::UI::Xaml::Media::SolidColorBrush(
+			winrt::Windows::UI::Colors::Transparent()));
+
+		AcrylicVisualWithBoundedCornerRadius acrylicLayer{ grid };
+		winrt::Microsoft::UI::Xaml::Controls::Grid::SetRow(acrylicLayer, 0);
+		winrt::Microsoft::UI::Xaml::Controls::Grid::SetRowSpan(acrylicLayer, 3);
+
+		grid.Children().InsertAt(0, acrylicLayer);
+	}
+
+	void PatchLightDismissSetters(winrt::Microsoft::UI::Xaml::Controls::Border const& contentRootGrid)
+	{
+		auto transparentBrush = winrt::Microsoft::UI::Xaml::Media::SolidColorBrush(
+			winrt::Windows::UI::Colors::Transparent());
+
+		auto groups = winrt::Microsoft::UI::Xaml::VisualStateManager::GetVisualStateGroups(contentRootGrid);
+		if (!groups) return;
+
+		for (auto const& group : groups)
+		{
+			if (group.Name() != L"LightDismissStates") continue;
+
+			for (auto const& state : group.States())
+			{
+				if (state.Name() != L"LightDismiss") continue;
+
+				for (auto const& setterBase : state.Setters())
+				{
+					auto setter = setterBase.try_as<winrt::Microsoft::UI::Xaml::Setter>();
+					if (!setter) continue;
+
+					auto target = setter.Target();
+					if (!target) continue;
+
+					auto PathName = target.Path().Path();
+
+					if (PathName == L"Background" || PathName == L"Fill")
+					{
+						setter.Value(transparentBrush);
+					}
+				}
+			}
+		}
+	}
+
+
+	void TeachingTipHelper::acrylicWorkaroundChanged(
+		winrt::Microsoft::UI::Xaml::DependencyObject const& object,
+		winrt::Microsoft::UI::Xaml::DependencyPropertyChangedEventArgs const& arg)
+	{
+		auto const acrylicWorkaround = winrt::unbox_value<bool>(arg.NewValue());
+
+		if (!acrylicWorkaround) return;
+
+		auto teachingTip = object.as<winrt::Microsoft::UI::Xaml::Controls::TeachingTip>();
+
+		teachingTip.Background(winrt::Microsoft::UI::Xaml::Media::SolidColorBrush{
+		   winrt::Windows::UI::Colors::Transparent()
+			});
+
+
+		auto teachingTipLoadedRevoker = std::make_shared<winrt::Microsoft::UI::Xaml::Controls::TeachingTip::Loaded_revoker>();
+		*teachingTipLoadedRevoker = teachingTip.Loaded(winrt::auto_revoke, [teachingTipLoadedRevoker](winrt::Windows::Foundation::IInspectable const& teachingTipRef, auto&&)
+		{
+			teachingTipLoadedRevoker->revoke();
+
+			auto teachingTip = teachingTipRef.as<winrt::Microsoft::UI::Xaml::Controls::TeachingTip>();
+
+			auto border = VisualTreeHelper::FindVisualChildByName<winrt::Microsoft::UI::Xaml::Controls::Border>(
+				teachingTip,
+				L"Container"
+			);
+
+			if (!border) return;
+
+			PatchLightDismissSetters(border);
+
+			auto borderLoadedRevoker = std::make_shared<winrt::Microsoft::UI::Xaml::Controls::Border::Loaded_revoker>();
+			*borderLoadedRevoker = border.Loaded(winrt::auto_revoke, [comboBoxRef = winrt::make_weak(teachingTip), borderLoadedRevoker](winrt::Windows::Foundation::IInspectable const& borderRef, auto&&)
+			{
+				borderLoadedRevoker->revoke();
+
+				auto border = borderRef.as<winrt::Microsoft::UI::Xaml::Controls::Border>();
+
+				auto contentRootGrid = border.FindName(L"ContentRootGrid").try_as<winrt::Microsoft::UI::Xaml::Controls::Grid>();
+
+				if (contentRootGrid) ApplyAcrylicToGrid(contentRootGrid);
+
+			});
+
+
+		});
+
+	}
+}

--- a/WinUI3Package/TeachingTipHelper.h
+++ b/WinUI3Package/TeachingTipHelper.h
@@ -1,0 +1,33 @@
+﻿#pragma once
+
+#include "TeachingTipHelper.g.h"
+
+namespace winrt::WinUI3Package::implementation
+{
+	struct TeachingTipHelper : TeachingTipHelperT<TeachingTipHelper>
+	{
+		TeachingTipHelper() = default;
+
+		static winrt::Microsoft::UI::Xaml::DependencyProperty AcrylicWorkaroundProperty();
+		static bool GetAcrylicWorkaround(winrt::Microsoft::UI::Xaml::Controls::TeachingTip const& teachingTip);
+		static void SetAcrylicWorkaround(
+			winrt::Microsoft::UI::Xaml::Controls::TeachingTip const& teachingTip,
+			bool value
+		);
+
+	private:
+		static winrt::Microsoft::UI::Xaml::DependencyProperty s_acrylicWorkaroundProperty;
+
+		static void acrylicWorkaroundChanged(
+			winrt::Microsoft::UI::Xaml::DependencyObject const& object,
+			winrt::Microsoft::UI::Xaml::DependencyPropertyChangedEventArgs const& arg
+		);
+	};
+}
+
+namespace winrt::WinUI3Package::factory_implementation
+{
+    struct TeachingTipHelper : TeachingTipHelperT<TeachingTipHelper, implementation::TeachingTipHelper>
+    {
+    };
+}

--- a/WinUI3Package/TeachingTipHelper.h
+++ b/WinUI3Package/TeachingTipHelper.h
@@ -6,8 +6,6 @@ namespace winrt::WinUI3Package::implementation
 {
 	struct TeachingTipHelper : TeachingTipHelperT<TeachingTipHelper>
 	{
-		TeachingTipHelper() = default;
-
 		static winrt::Microsoft::UI::Xaml::DependencyProperty AcrylicWorkaroundProperty();
 		static bool GetAcrylicWorkaround(winrt::Microsoft::UI::Xaml::Controls::TeachingTip const& teachingTip);
 		static void SetAcrylicWorkaround(

--- a/WinUI3Package/TeachingTipHelper.idl
+++ b/WinUI3Package/TeachingTipHelper.idl
@@ -1,0 +1,12 @@
+﻿namespace WinUI3Package
+{
+    [bindable]
+    [default_interface]
+    runtimeclass TeachingTipHelper 
+    {
+        TeachingTipHelper();
+        static Microsoft.UI.Xaml.DependencyProperty AcrylicWorkaroundProperty{get; };
+        static Boolean GetAcrylicWorkaround(Microsoft.UI.Xaml.Controls.TeachingTip teachingTip);
+        static void SetAcrylicWorkaround(Microsoft.UI.Xaml.Controls.TeachingTip teachingTip, Boolean value);
+    }
+}

--- a/WinUI3Package/TeachingTipHelper.idl
+++ b/WinUI3Package/TeachingTipHelper.idl
@@ -4,7 +4,6 @@
     [default_interface]
     runtimeclass TeachingTipHelper 
     {
-        TeachingTipHelper();
         static Microsoft.UI.Xaml.DependencyProperty AcrylicWorkaroundProperty{get; };
         static Boolean GetAcrylicWorkaround(Microsoft.UI.Xaml.Controls.TeachingTip teachingTip);
         static void SetAcrylicWorkaround(Microsoft.UI.Xaml.Controls.TeachingTip teachingTip, Boolean value);

--- a/WinUI3Package/WinUI3Package.vcxproj
+++ b/WinUI3Package/WinUI3Package.vcxproj
@@ -552,6 +552,10 @@
     <ClInclude Include="TaskbarIconBase.h" />
     <ClInclude Include="TaskbarIconMessageWindow.h" />
     <ClInclude Include="TaskbarIconXamlEvents.h" />
+    <ClInclude Include="TeachingTipHelper.h">
+      <DependentUpon>TeachingTipHelper.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="TenMicaBackdrop.h">
       <DependentUpon>TenMicaBackdrop.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -886,6 +890,10 @@
     </ClCompile>
     <ClCompile Include="TaskbarIconBase.cpp" />
     <ClCompile Include="TaskbarIconMessageWindow.cpp" />
+    <ClCompile Include="TeachingTipHelper.cpp">
+      <DependentUpon>TeachingTipHelper.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="TenMicaBackdrop.cpp">
       <DependentUpon>TenMicaBackdrop.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -1138,6 +1146,9 @@
       <SubType>Designer</SubType>
     </Midl>
     <Midl Include="TaskbarIcon.idl">
+      <SubType>Designer</SubType>
+    </Midl>
+    <Midl Include="TeachingTipHelper.idl">
       <SubType>Designer</SubType>
     </Midl>
     <Midl Include="TenMicaBackdrop.idl">

--- a/WinUI3Package/WinUI3Package.vcxproj.filters
+++ b/WinUI3Package/WinUI3Package.vcxproj.filters
@@ -608,10 +608,10 @@
     <Midl Include="CustomBackdropBase.idl">
       <Filter>Backdrop</Filter>
     </Midl>
-    <Midl Include="NavigationViewItemHelper.idl">
+    <Midl Include="SliderHelper.idl">
       <Filter>Controls\Helpers</Filter>
     </Midl>
-    <Midl Include="SliderHelper.idl">
+    <Midl Include="TeachingTipHelper.idl">
       <Filter>Controls\Helpers</Filter>
     </Midl>
   </ItemGroup>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches low-level visual-tree/template manipulation for `TeachingTip`, which can be fragile across WinUI template changes and may affect rendering or dismiss behavior, but it’s opt-in via an attached property.
> 
> **Overview**
> Adds **`WinUI3Package::TeachingTipHelper`** (IDL + implementation) exposing an attached `AcrylicWorkaround` property for `TeachingTip` that, when enabled, patches the control’s template at load time (transparent background/light-dismiss setters, injects an acrylic visual layer, and adjusts tail border rendering).
> 
> Updates the WinUI3 example app to include a new `TeachingTipHelperPage` demonstrating the attached property and registers it in the main page list/navigation; project files (`.vcxproj` and `.filters`) are updated to build/include the new page and helper sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c6365b87d271c6114deba65fe9502e79158f613. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->