### PR TITLE
Implement ScopedButtonDisabler in Button_Click handlers

### DIFF
--- a/WinUI3Example/AboutPage.xaml.cpp
+++ b/WinUI3Example/AboutPage.xaml.cpp
@@ -132,6 +132,7 @@ namespace winrt::WinUI3Example::implementation
 	{
 		try
 		{
+			auto strongThis = get_strong();
 			auto result = co_await client.SendRequestAsync(GithubRequest{ L"https://api.github.com/repos/HO-COOH/WinUIEssentials/contributors" });
 			auto resultStr = co_await result.Content().ReadAsStringAsync();
 
@@ -164,6 +165,7 @@ namespace winrt::WinUI3Example::implementation
 	{
 		try
 		{
+			auto strongThis = get_strong();
 			auto result = co_await client.SendRequestAsync(GithubRequest{ L"https://api.github.com/repos/HO-COOH/WinUIEssentials" });
 			auto resultStr = co_await result.Content().ReadAsStringAsync();
 
@@ -183,6 +185,7 @@ namespace winrt::WinUI3Example::implementation
 	{
 		try
 		{
+			auto strongThis = get_strong();
 			auto result = co_await client.SendRequestAsync(GithubRequest{ L"https://api.github.com/repos/HO-COOH/WinUIEssentials/commits?per_page=1" });
 			auto resultStr = co_await result.Content().ReadAsStringAsync();
 			m_commitMessage = winrt::Windows::Data::Json::JsonArray::Parse(resultStr).GetAt(0).GetObjectW().GetNamedObject(L"commit").GetNamedString(L"message");
@@ -222,6 +225,7 @@ namespace winrt::WinUI3Example::implementation
 	{
 		try
 		{
+			auto strongThis = get_strong();
 			auto result = co_await client.GetStringAsync(winrt::Windows::Foundation::Uri{ L"https://nuget.azure.cn/v3/index.json" });
 			auto resources = winrt::Windows::Data::Json::JsonObject::Parse(result).GetNamedArray(L"resources");
 			for (auto resource : resources)

--- a/WinUI3Example/CodeSource.cpp
+++ b/WinUI3Example/CodeSource.cpp
@@ -28,7 +28,12 @@ namespace winrt::WinUI3Example::implementation
     }
     void CodeSource::Code(winrt::hstring const& value)
     {
+        if (m_code == value)
+            return;
+
         m_code = value;
+        if (ValueChanged)
+            ValueChanged(FormatCode());
     }
     winrt::Windows::Foundation::Uri CodeSource::CodeUrl()
     {

--- a/WinUI3Example/Editor.xaml
+++ b/WinUI3Example/Editor.xaml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <UserControl
     x:Class="WinUI3Example.Editor"
+    Loaded="Editor_Loaded"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/WinUI3Example/Editor.xaml.cpp
+++ b/WinUI3Example/Editor.xaml.cpp
@@ -3,7 +3,9 @@
 #if __has_include("Editor.g.cpp")
 #include "Editor.g.cpp"
 #endif
+#include "CodeSource.h"
 #include <winrt/Microsoft.Web.WebView2.Core.h>
+#include <winrt/Windows.Data.Json.h>
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -35,18 +37,73 @@ namespace winrt::WinUI3Example::implementation
         return winrt::hstring{ rtrim(ltrim(value)) };
     }
 
-    std::wstring Editor::getJavascript()
+    std::wstring Editor::getCreateEditorJavascript() const
     {
         return std::format(LR"(window.editor = window.create(document.getElementById('container'), 
     {{
-        value: String.raw`{}`,
+        value: {},
         automaticLayout: true,
         readOnly: true,
         "semanticHighlighting.enabled": true,
         language: '{}',
         theme: 'vs-dark'
     }});
-)", m_code.data(), languageString());
+)", winrt::Windows::Data::Json::JsonValue::CreateStringValue(m_code).Stringify(), languageString());
+    }
+
+    std::wstring Editor::getSetCodeJavascript() const
+    {
+        return std::format(
+            LR"(if (window.editor) {{ window.editor.setValue({}); }})",
+            winrt::Windows::Data::Json::JsonValue::CreateStringValue(m_code).Stringify()
+        );
+    }
+
+    winrt::fire_and_forget Editor::UpdateEditorCode()
+    {
+        auto strongThis = get_strong();
+        if (m_closed || !m_editorReady)
+            co_return;
+
+        try
+        {
+            auto coreWebView = EditorWebView().CoreWebView2();
+            if (!coreWebView)
+            {
+                co_return;
+            }
+
+            co_await coreWebView.ExecuteScriptAsync(getSetCodeJavascript());
+            if (!m_closed)
+            {
+                Height(measureHeight(m_code));
+                LoadingProgress().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+            }
+        }
+        catch (...)
+        {
+        }
+    }
+
+    void Editor::Editor_Loaded(
+        winrt::Windows::Foundation::IInspectable const&,
+        winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
+    {
+        m_closed = false;
+        if (auto codeSource = DataContext().try_as<winrt::WinUI3Example::CodeSource>())
+        {
+            auto weakThis = get_weak();
+            auto codeSourceImpl = winrt::get_self<winrt::WinUI3Example::implementation::CodeSource>(codeSource);
+            codeSourceImpl->ValueChanged = [weakThis](std::wstring const& value)
+            {
+                if (auto self = weakThis.get())
+                {
+                    self->Code(winrt::hstring{ value });
+                }
+            };
+
+            Code(winrt::hstring{ codeSourceImpl->FormatCode() });
+        }
     }
 
 	void Editor::WebView2_Closed(
@@ -67,7 +124,7 @@ namespace winrt::WinUI3Example::implementation
             winrt::Microsoft::Web::WebView2::Core::CoreWebView2HostResourceAccessKind::Allow
         );
         sender.Source(winrt::Windows::Foundation::Uri{ L"https://local/Monaco.html" });
-        sender.NavigationCompleted([weakThis = get_weak(), js = getJavascript()](
+        sender.NavigationCompleted([weakThis = get_weak()](
             winrt::Microsoft::UI::Xaml::Controls::WebView2 const& sender, 
             winrt::Microsoft::Web::WebView2::Core::CoreWebView2NavigationCompletedEventArgs const& args)->winrt::Windows::Foundation::IAsyncAction
         {
@@ -76,12 +133,17 @@ namespace winrt::WinUI3Example::implementation
                     if (!strongThis->m_closed && !strongThis->m_code.empty())
                     {
                         auto coreWebView = sender.CoreWebView2();
-                        co_await coreWebView.ExecuteScriptAsync(js);
-                        if (auto s = weakThis.get(); s && !s->m_closed)
+                        co_await coreWebView.ExecuteScriptAsync(strongThis->getCreateEditorJavascript());
+                        if (!strongThis->m_closed)
                         {
-                            s->Height(measureHeight(s->m_code));
-                            s->LoadingProgress().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
+                            strongThis->m_editorReady = true;
+                            strongThis->Height(measureHeight(strongThis->m_code));
+                            strongThis->LoadingProgress().Visibility(winrt::Microsoft::UI::Xaml::Visibility::Collapsed);
                         }
+                    }
+                    else if (!strongThis->m_closed)
+                    {
+                        strongThis->m_editorReady = true;
                     }
                 }
         });
@@ -95,6 +157,7 @@ namespace winrt::WinUI3Example::implementation
     void Editor::Code(winrt::hstring const& value)
     {
         m_code = value;
+        UpdateEditorCode();
     }
 
     winrt::WinUI3Example::Language Editor::CodeLanguage()
@@ -111,4 +174,5 @@ namespace winrt::WinUI3Example::implementation
 void winrt::WinUI3Example::implementation::Editor::EditorWebView_Unloaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e)
 {
     m_closed = true;
+    m_editorReady = false;
 }

--- a/WinUI3Example/Editor.xaml.h
+++ b/WinUI3Example/Editor.xaml.h
@@ -10,6 +10,8 @@ namespace winrt::WinUI3Example::implementation
 
         winrt::hstring Code();
         void Code(winrt::hstring const& value);
+        winrt::fire_and_forget UpdateEditorCode();
+        void Editor_Loaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
         void WebView2_CoreWebView2Initialized(winrt::Microsoft::UI::Xaml::Controls::WebView2 const& sender, winrt::Microsoft::UI::Xaml::Controls::CoreWebView2InitializedEventArgs const& args);
         void WebView2_Closed(winrt::Microsoft::UI::Xaml::Controls::WebView2 const& sender, winrt::Windows::Foundation::IInspectable const& args);
         
@@ -26,7 +28,8 @@ namespace winrt::WinUI3Example::implementation
         static std::wstring_view rtrim(std::wstring_view str);
         static winrt::hstring stripEmptyLine(winrt::hstring const& value);
         
-        std::wstring getJavascript();
+        std::wstring getCreateEditorJavascript() const;
+        std::wstring getSetCodeJavascript() const;
         constexpr wchar_t const* languageString() const
         {
             switch (m_language)
@@ -44,6 +47,7 @@ namespace winrt::WinUI3Example::implementation
         }
         
         winrt::hstring m_code;
+        bool m_editorReady{};
     public:
         void EditorWebView_Unloaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
     };

--- a/WinUI3Example/WindowedContentDialogPage.idl
+++ b/WinUI3Example/WindowedContentDialogPage.idl
@@ -4,5 +4,7 @@
     runtimeclass WindowedContentDialogPage : Microsoft.UI.Xaml.Controls.Page
     {
         WindowedContentDialogPage();
+
+        static String GetWindowedContentDialogSampleCppSource(WinUI3Package.UnderlayMode mode);
     }
 }

--- a/WinUI3Example/WindowedContentDialogPage.xaml
+++ b/WinUI3Example/WindowedContentDialogPage.xaml
@@ -75,11 +75,7 @@
             </local:ControlExample.Xaml>
 
             <local:ControlExample.Cpp>
-                <local:CodeSource>
-                    <local:CodeSource.Code>
-                        <x:String xml:space="preserve">co_await WinUI3Example::SampleWindowedContentDialog{}.ShowAsync(App::AppInstance->window);</x:String>
-                    </local:CodeSource.Code>
-                </local:CodeSource>
+                <local:CodeSource Code="{x:Bind local:WindowedContentDialogPage.GetWindowedContentDialogSampleCppSource((essential:UnderlayMode)((ComboBoxItem)UnderlayModeComboBox.SelectedItem).Tag), Mode=OneWay}" />
             </local:ControlExample.Cpp>
         </local:ControlExample>
     </StackPanel>

--- a/WinUI3Example/WindowedContentDialogPage.xaml.cpp
+++ b/WinUI3Example/WindowedContentDialogPage.xaml.cpp
@@ -5,7 +5,7 @@
 #endif
 #include "App.xaml.h"
 
-#include <include/ScopedButtonDisabler.hpp>
+#include <ScopedButtonDisabler.hpp>
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.

--- a/WinUI3Example/WindowedContentDialogPage.xaml.cpp
+++ b/WinUI3Example/WindowedContentDialogPage.xaml.cpp
@@ -55,4 +55,35 @@ namespace winrt::WinUI3Example::implementation
 		}
 	}
 
+	winrt::hstring WindowedContentDialogPage::GetWindowedContentDialogSampleCppSource(winrt::WinUI3Package::UnderlayMode mode)
+	{
+		switch (mode)
+		{
+			case winrt::WinUI3Package::UnderlayMode::None:
+				return LR"(winrt::fire_and_forget WindowedContentDialogPage::Button_Click_1(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
+{
+	ScopedButtonDisabler disabler{ sender };
+	auto const result = co_await WinUI3Example::SampleWindowedContentDialog{}.ShowAsync(App::AppInstance->window);
+})";
+			case winrt::WinUI3Package::UnderlayMode::Blur:
+				return LR"(winrt::fire_and_forget WindowedContentDialogPage::Button_Click_1(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
+{
+	ScopedButtonDisabler disabler{ sender };
+	auto const result = co_await WinUI3Example::SampleWindowedContentDialog{}.ShowAsync(
+		App::AppInstance->window, 
+		winrt::WinUI3Package::UnderlayMode::Blur
+	);
+})";
+			case winrt::WinUI3Package::UnderlayMode::Smoke:
+				return LR"(winrt::fire_and_forget WindowedContentDialogPage::Button_Click_1(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
+{
+	ScopedButtonDisabler disabler{ sender };
+	auto const result = co_await WinUI3Example::SampleWindowedContentDialog{}.ShowAsync(
+		App::AppInstance->window, 
+		winrt::WinUI3Package::UnderlayMode::Smoke
+	);
+})";
+		}
+	}
+
 }

--- a/WinUI3Example/WindowedContentDialogPage.xaml.cpp
+++ b/WinUI3Example/WindowedContentDialogPage.xaml.cpp
@@ -5,15 +5,16 @@
 #endif
 #include "App.xaml.h"
 
+#include <include/ScopedButtonDisabler.hpp>
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace winrt::WinUI3Example::implementation
 {
-	winrt::fire_and_forget WindowedContentDialogPage::Button_Click(winrt::Windows::Foundation::IInspectable const&, winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
-	{
-
+	winrt::fire_and_forget WindowedContentDialogPage::Button_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
+	{		
+    	ScopedButtonDisabler disabler{ sender };
 		WinUI3Package::ModernDialogBox dialog;
 
 		auto content = dialog.DialogContent();
@@ -33,8 +34,9 @@ namespace winrt::WinUI3Example::implementation
 
 	}
 
-	winrt::fire_and_forget WindowedContentDialogPage::Button_Click_1(winrt::Windows::Foundation::IInspectable const&, winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
+	winrt::fire_and_forget WindowedContentDialogPage::Button_Click_1(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
 	{
+		ScopedButtonDisabler disabler{ sender };
 		auto const result = co_await WinUI3Example::SampleWindowedContentDialog{}.ShowAsync(
 			App::AppInstance->window, 
 			winrt::unbox_value<winrt::WinUI3Package::UnderlayMode>(UnderlayModeComboBox().SelectedItem().as<winrt::Microsoft::UI::Xaml::Controls::ComboBoxItem>().Tag())

--- a/WinUI3Example/WindowedContentDialogPage.xaml.h
+++ b/WinUI3Example/WindowedContentDialogPage.xaml.h
@@ -9,6 +9,7 @@ namespace winrt::WinUI3Example::implementation
         WindowedContentDialogPage() = default;
         winrt::fire_and_forget Button_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
         winrt::fire_and_forget Button_Click_1(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
+        static winrt::hstring GetWindowedContentDialogSampleCppSource(winrt::WinUI3Package::UnderlayMode mode);
     };
 }
 


### PR DESCRIPTION
Added ScopedButtonDisabler to Button_Click methods to prevent multiple clicks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WinUI coroutine/event lifetimes and WebView2 script execution; regressions could surface as stale UI, missed updates, or crashes if lifecycle handling is still incorrect.
> 
> **Overview**
> Improves UI robustness around async operations by capturing a strong `this` in `AboutPage` coroutine loaders and by adding `ScopedButtonDisabler` to `WindowedContentDialogPage` click handlers to prevent repeated dialog invocations.
> 
> Refactors the Monaco `Editor` control to safely inject code via JSON-escaped strings, track an `m_editorReady` state, and update the displayed code when the `CodeSource` changes (hooked on `Loaded`). The `WindowedContentDialogPage` C++ sample snippet is now generated dynamically based on the selected `UnderlayMode` via a new `GetWindowedContentDialogSampleCppSource` API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6634f145d563abc1e2eeae03e27f77647ba4522e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->